### PR TITLE
feat: KUBERNETES-1240 - add jws authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,19 +3,18 @@
 [![ci](https://github.com/neticdk-k8s/k8s-inventory-client/actions/workflows/main.yml/badge.svg)](https://github.com/neticdk-k8s/k8s-inventory-client/actions/workflows/main.yml)
 [![tag](https://img.shields.io/github/tag/neticdk-k8s/k8s-inventory-client.svg)](https://github.com/neticdk-k8s/k8s-inventory-client/tags/)
 
-
 Kubernetes application that collects, exposes and optionally uploads inventory
 data.
 
 It runs in a loop every `COLLECT_INTERNAL` and collects:
 
-* Cluster information (versions, etc)
-* Workload information (deployments, etc)
-* Infrastructure information (cloud, region, zone, etc)
-* Node information
-* Storage information
-* Secure Cloud Stack specific information (customer data, etc)
-* Custom Resource information (CNI, specific operators)
+- Cluster information (versions, etc)
+- Workload information (deployments, etc)
+- Infrastructure information (cloud, region, zone, etc)
+- Node information
+- Storage information
+- Secure Cloud Stack specific information (customer data, etc)
+- Custom Resource information (CNI, specific operators)
 
 For more information about what is collected, see
 [k8s-inventory](https://github.com/neticdk-k8s/k8s-inventory).
@@ -44,8 +43,8 @@ Secure Cloud Stack Information is read from `ConfigMap`-objects.
 
 These objects must be created in the `netic-metadata-system` `Namespace`:
 
-* General cluster information uses the first `ConfigMap` matching the `netic.dk/owned-by=operator` label
-* Tenant information uses all `ConfigMap`s matching the `netic.dk/owned-by=tenant` label
+- General cluster information uses the first `ConfigMap` matching the `netic.dk/owned-by=operator` label
+- Tenant information uses all `ConfigMap`s matching the `netic.dk/owned-by=tenant` label
 
 See [`dist/deployment/netic-metadata.yaml`](dist/deployment/netic-metadata.yaml) for examples.
 
@@ -59,40 +58,42 @@ for a list of permissions.
 
 Configuration is done using environment variables:
 
-| Variable Name         | Description                    | Default |
-| :-------------------- | :----------------------------  | ------: |
-| `HTTP_PORT`           | HTTP port to listen on         |    8087 |
-| `COLLECT_INTERNAL`    | How often to collect           |      1h |
-| `LOG_LEVEL`           | Logging level                  |    info |
-| `LOG_FORMATTER`       | Log output formatter           |    json |
-| `UPLOAD_INVENTORY`    | Upload inventory               |    true |
-| `SERVER_API_ENDPOINT` | HTTP URL to upload data to     | http://localhost:8086/api/v1/inventory |
-| `IMPERSONATE`         | Kubernetes role to imporsonate |         |
+| Variable Name         | Description                                    |                                Default |
+| :-------------------- | :--------------------------------------------- | -------------------------------------: |
+| `HTTP_PORT`           | HTTP port to listen on                         |                                   8087 |
+| `COLLECT_INTERNAL`    | How often to collect                           |                                     1h |
+| `LOG_LEVEL`           | Logging level                                  |                                   info |
+| `LOG_FORMATTER`       | Log output formatter                           |                                   json |
+| `UPLOAD_INVENTORY`    | Upload inventory                               |                                   true |
+| `SERVER_API_ENDPOINT` | HTTP URL to upload data to                     | http://localhost:8086/api/v1/inventory |
+| `AUTH_ENABLED`        | Enable/disable authentication                  |                                   true |
+| `TLS_CRT`             | PEM Certificate file to use for authentication |              /etc/certificates/tls.crt |
+| `TLS_KEY`             | PEM KEY file to use for authentication         |              /etc/certificates/tls.key |
+| `SERVER_API_ENDPOINT` | HTTP URL to upload data to                     | http://localhost:8086/api/v1/inventory |
+| `IMPERSONATE`         | Kubernetes role to imporsonate                 |                                        |
 
 ### Collection Intervals
 
 `COLLECT_INTERNAL` takes a values that can be parsed by
 [`time.ParseDuration()`](https://pkg.go.dev/time#Duration).
 
-
 ### Log Formatter
 
 `LOG_FORMATTER` can be set to one of:
 
-* json
-* text
-
+- json
+- text
 
 ### Log Level
 
 `LOG_LEVEL` can be set to one of:
 
-* debug
-* info
-* warn
-* error
-* fatal
-* panic
+- debug
+- info
+- warn
+- error
+- fatal
+- panic
 
 ## Deploying
 
@@ -100,13 +101,13 @@ If you use a Secure Cloud Stack cluster, chances are k8s-inventory-client is alr
 
 However, if you need to deploy it yourself, you will need to:
 
-* Create the `ConfigMap`s mentioned above
-* Create the Kubernetes resources:
-    * ServiceAccount
-    * ClusterRole
-    * ClusterRoleBinding
-    * Service
-    * Deployment
+- Create the `ConfigMap`s mentioned above
+- Create the Kubernetes resources:
+  - ServiceAccount
+  - ClusterRole
+  - ClusterRoleBinding
+  - Service
+  - Deployment
 
 See [`kustomization.yaml`](dist/deployment/kustomization.yaml) for a full example of deploying the client.
 
@@ -116,10 +117,10 @@ See [`kustomization.yaml`](dist/deployment/kustomization.yaml) for a full exampl
 
 Typical adjustments:
 
-* Set the `app.kubernetes.io/version` label to match the image version
-* Set the image tag to the version you want to deploy
-* In the `Deployment` set environment variables accordingly
-* If using another port, set the `Service` ports
+- Set the `app.kubernetes.io/version` label to match the image version
+- Set the image tag to the version you want to deploy
+- In the `Deployment` set environment variables accordingly
+- If using another port, set the `Service` ports
 
 ## Building
 

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -221,11 +221,11 @@ func (c *InventoryCollection) Upload() error {
 	}
 
 	if c.AuthEnabled {
-		jwt, err := c.Signer.Sign(payload)
+		jws, err := c.Signer.Sign(payload)
 		if err != nil {
 			return errors.Wrap(err, "signing inventory")
 		}
-		payload = []byte(jwt.FullSerialize())
+		payload = []byte(jws.FullSerialize())
 		contentType = "application/jose+json"
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	env "github.com/Netflix/go-env"
+	"github.com/rs/zerolog/log"
+)
+
+type Config struct {
+	Logging struct {
+		Level     string `env:"LOG_LEVEL,default=info"`
+		Formatter string `env:"LOG_FORMATTER,default=json"`
+	}
+	CollectionInterval string `env:"COLLECT_INTERVAL,default=1h"`
+	UploadInventory    bool   `env:"UPLOAD_INVENTORY,default=true"`
+	Impersonate        string `env:"IMPERSONATE"`
+	ServerAPIEndpoint  string `env:"SERVER_API_ENDPOINT,default=http://localhost:8086"`
+	HTTPPort           string `env:"HTTP_PORT,default=8087"`
+	TLSCrt             string `env:"TLS_CRT,default=/etc/certificates/tls.crt"`
+	TLSKey             string `env:"TLS_KEY,default=/etc/certificates/tls.key"`
+	AuthEnabled        bool   `env:"AUTH_ENABLED,default=true"`
+	Extras             env.EnvSet
+}
+
+func NewConfig() Config {
+	var c Config
+	es, err := env.UnmarshalFromEnviron(&c)
+	if err != nil {
+		log.Fatal().Err(err).Msg("getting environment variables")
+	}
+	c.Extras = es
+	return c
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.21.5
 
 require (
 	github.com/Masterminds/semver v1.5.0
+	github.com/Netflix/go-env v0.0.0-20220526054621-78278af1949d
 	github.com/kloeckner-i/db-operator v1.10.0
 	github.com/neticdk-k8s/k8s-inventory v0.2.10
 	github.com/pkg/errors v0.9.1
@@ -14,6 +15,7 @@ require (
 	github.com/rancher/kubernetes-provider-detector v0.1.5
 	github.com/rs/zerolog v1.31.0
 	github.com/vmware-tanzu/velero v1.12.2
+	gopkg.in/go-jose/go-jose.v2 v2.6.2
 	k8s.io/api v0.26.11
 	k8s.io/apimachinery v0.28.0-alpha.0
 	k8s.io/client-go v0.26.11
@@ -54,6 +56,7 @@ require (
 	github.com/prometheus/procfs v0.10.1 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/crypto v0.14.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/oauth2 v0.10.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
+github.com/Netflix/go-env v0.0.0-20220526054621-78278af1949d h1:wvStE9wLpws31NiWUx+38wny1msZ/tm+eL5xmm4Y7So=
+github.com/Netflix/go-env v0.0.0-20220526054621-78278af1949d/go.mod h1:9XMFaCeRyW7fC9XJOWQ+NdAv8VLG7ys7l3x4ozEGLUQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -293,18 +295,6 @@ github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8m
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
-github.com/neticdk-k8s/k8s-inventory v0.2.3 h1:XEyendtFfmUDS2C0K01NHQ7UHofkrUF385KqxMAiD0g=
-github.com/neticdk-k8s/k8s-inventory v0.2.3/go.mod h1:9lGHR4HpVF5DEJKDynMXo0fyir4ec+2oEfkE7PS8yy0=
-github.com/neticdk-k8s/k8s-inventory v0.2.4 h1:HYYoLJgATNEcwLSfDSjO4TNeq2dCZuKoDMzRSyARq6I=
-github.com/neticdk-k8s/k8s-inventory v0.2.4/go.mod h1:9lGHR4HpVF5DEJKDynMXo0fyir4ec+2oEfkE7PS8yy0=
-github.com/neticdk-k8s/k8s-inventory v0.2.5 h1:+VoHz6eE8M8Ni1qz1+C9+m4+lH8JGi5JbNToD7jWzhI=
-github.com/neticdk-k8s/k8s-inventory v0.2.5/go.mod h1:9lGHR4HpVF5DEJKDynMXo0fyir4ec+2oEfkE7PS8yy0=
-github.com/neticdk-k8s/k8s-inventory v0.2.7 h1:YU5epN3bBGtcghgvkEY6qjJDNJt//Irl9HHSUq7kAaE=
-github.com/neticdk-k8s/k8s-inventory v0.2.7/go.mod h1:9lGHR4HpVF5DEJKDynMXo0fyir4ec+2oEfkE7PS8yy0=
-github.com/neticdk-k8s/k8s-inventory v0.2.8 h1:SL+HyBgw4HPPzxRIP911ad9yrDp0Q0Z/3AAAn82D6tg=
-github.com/neticdk-k8s/k8s-inventory v0.2.8/go.mod h1:9lGHR4HpVF5DEJKDynMXo0fyir4ec+2oEfkE7PS8yy0=
-github.com/neticdk-k8s/k8s-inventory v0.2.9 h1:g1lLDoHp7wl+82v35E562xyRr9r5QgEAQNftqKa2hM4=
-github.com/neticdk-k8s/k8s-inventory v0.2.9/go.mod h1:9lGHR4HpVF5DEJKDynMXo0fyir4ec+2oEfkE7PS8yy0=
 github.com/neticdk-k8s/k8s-inventory v0.2.10 h1:Qpcykz8EyGAMSHjpk03/iDqN+2/X2Bo3vhp8k+qtEe8=
 github.com/neticdk-k8s/k8s-inventory v0.2.10/go.mod h1:9lGHR4HpVF5DEJKDynMXo0fyir4ec+2oEfkE7PS8yy0=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
@@ -409,6 +399,8 @@ golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.14.0 h1:wBqGXzWJW6m1XrIKlAH0Hs1JJ7+9KBwnIO8v66Q9cHc=
+golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -760,6 +752,8 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/go-jose/go-jose.v2 v2.6.2 h1:Rl5+9rA0kG3vsO1qhncMPRT5eHICihAMQYJkD7u/i4M=
+gopkg.in/go-jose/go-jose.v2 v2.6.2/go.mod h1:zzZDPkNNw/c9IE7Z9jr11mBZQhKQTMzoEEIoEdZlFBI=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=

--- a/main.go
+++ b/main.go
@@ -3,42 +3,28 @@ package main
 import (
 	"net/http"
 	_ "net/http/pprof"
-	"os"
 
 	"github.com/neticdk-k8s/k8s-inventory-client/collect"
 	"github.com/neticdk-k8s/k8s-inventory-client/collect/version"
+	"github.com/neticdk-k8s/k8s-inventory-client/config"
 	"github.com/neticdk-k8s/k8s-inventory-client/logging"
 	"github.com/rs/zerolog/log"
 )
 
-func getDefaultValue(envVar, def string) string {
-	r, ok := os.LookupEnv(envVar)
-	if !ok {
-		return def
-	}
-	return r
-}
-
 func main() {
-	logLevel := getDefaultValue("LOG_LEVEL", "info")
-	logFormatter := getDefaultValue("LOG_FORMATTER", "json")
-	logging.InitLogger(logLevel, logFormatter)
+	cfg := config.NewConfig()
+	logging.InitLogger(cfg.Logging.Level, cfg.Logging.Formatter)
 
 	log.Info().Str("version", version.VERSION).Str("commit", version.COMMIT).Msg("starting k8s-inventory-client")
 
-	collectionInterval := getDefaultValue("COLLECT_INTERVAL", collect.DefaultCollectionInterval)
-	uploadInventory := getDefaultValue("UPLOAD_INVENTORY", "true")
-	impersonate := getDefaultValue("IMPERSONATE", "")
-	serverAPIEndpoint := getDefaultValue("SERVER_API_ENDPOINT", "http://localhost:8086")
-	collection := collect.NewInventoryCollection(collectionInterval, uploadInventory, impersonate, serverAPIEndpoint)
+	collection := collect.NewInventoryCollection(cfg)
 
 	go collection.Collect()
 
 	http.Handle("/api/v1/inventory", collection)
 
-	port := getDefaultValue("HTTP_PORT", "8087")
-	log.Info().Str("port", port).Msg("starting server")
-	err := http.ListenAndServe(":"+port, nil)
+	log.Info().Str("port", cfg.HTTPPort).Msg("starting server")
+	err := http.ListenAndServe(":"+cfg.HTTPPort, nil)
 	if err != nil {
 		log.Fatal().Err(err).Msg("")
 	}


### PR DESCRIPTION
Adds authentication against the inventory server to the inventory client.

Use environment variables `TLS_CRT` and `TLS_KEY` to point to respective locations in the filesystem. They default to `/etc/certificates/tls.crt` and `/etc/certificates/tls.key`.

Authentication is enabled by default. Use environment variable `AUTH_ENABLED=false` to disable authentication. If the certificate files are not found it degrades gracefully and authentication will be disabled.

I also moved around the configuration to make it like inventory-server.